### PR TITLE
Scene refactor

### DIFF
--- a/Source/main.lua
+++ b/Source/main.lua
@@ -4,179 +4,24 @@ import "Corelibs/sprites"
 import "Corelibs/timer"
 import "Corelibs/ui"
 
-local ui = import "ui"
-local gfx <const> = playdate.graphics
-
-local snd = playdate.sound
-local captureSynth = snd.synth.new(snd.kWaveSquare)
-
-local screenWidth, screenHeight = playdate.display.getWidth(), playdate.display.getHeight() 
-
-local beamRadius = 20 -- Initial Beam radius, will be adjusted by the crank
-local beamX, beamY = screenWidth / 2, screenHeight / 2 -- Initial circle position
-local minBeamRadius = 5
-local maxBeamRadius = 75
-
--- Add this: generate random dots
-local numStars = 50
-local stars = {}
-math.randomseed(playdate.getSecondsSinceEpoch())
-for i = 1, numStars do
-    table.insert(stars, {
-        x = math.random(0, screenWidth),
-        y = math.random(0, screenHeight),
-        size = math.random(1, 2) -- Random size between 1 and 3
-    })
-end
-
-local flyingObjects = {}
-local maxFlyingObjects = 3
-local maxObjectSize = maxBeamRadius / 3
-
-function spawnFlyingObject()
-    table.insert(flyingObjects, {
-        x = math.random(0, screenWidth),
-        y = math.random(0, screenHeight - 32),
-        size = 1,
-        speed = math.random(1, 3) / 10 -- How fast it grows
-    })
-end
-
--- Initialize flying objects
-for i = 1, maxFlyingObjects do
-    spawnFlyingObject()
-end
-
-local caught = 0
-local missed = 0
-local score = 0
-
--- Table to hold score popups
-local scorePopups = {}
+_G.ui = import "ui"
+local scene_manager = import "scenes/scene_manager"
+local menu_scene = import "scenes/menu_scene"
+local game_scene = import "scenes/game_scene"
 
 function playdate.update()
-    gfx.clear(gfx.kColorBlack)
-
-    -- Draw white stars in the background
-    gfx.setColor(gfx.kColorWhite)
-    local maxOffset = 3
-    local dx = math.max(-maxOffset, math.min(maxOffset, (beamX - screenWidth/2) * 0.01))
-    local dy = math.max(-maxOffset, math.min(maxOffset, (beamY - screenHeight/2) * 0.01))
-    for i = 1, #stars do
-        -- Larger dots move more with parallax
-        local px = stars[i].x - dx * stars[i].size
-        local py = stars[i].y - dy * stars[i].size
-        if stars[i].size == 1 then
-            gfx.drawPixel(px, py)
-        else
-            -- Draw a cross for larger dots
-            gfx.drawLine(px - 2, py, px + 2, py)   -- horizontal line
-            gfx.drawLine(px, py - 2, px, py + 2)   -- vertical line
-        end
-    end
-
-    -- Draw the circle at its current position
-    local cx, cy = math.floor(beamX + 0.5), math.floor(beamY + 0.5)
-    local innerRadius = math.floor(beamRadius + 0.5)
-    local outerRadius = math.floor(beamRadius + (beamRadius / 10) + 0.5)
-    gfx.drawCircleAtPoint(cx, cy, innerRadius)
-    gfx.drawCircleAtPoint(cx, cy, outerRadius)
-
-    -- Movement speed inversely proportional to radius
-    local moveSpeed = math.max(5, math.floor(beamRadius / 5))
-    if playdate.buttonIsPressed(playdate.kButtonUp) then
-        beamY = beamY - moveSpeed
-    end
-    if playdate.buttonIsPressed(playdate.kButtonDown) then
-        beamY = beamY + moveSpeed
-    end
-    if playdate.buttonIsPressed(playdate.kButtonLeft) then
-        beamX = beamX - moveSpeed
-    end
-    if playdate.buttonIsPressed(playdate.kButtonRight) then
-        beamX = beamX + moveSpeed
-    end
-
-    -- Clamp circle center to screen boundaries minus the UI
-    beamX = math.max(0, math.min(screenWidth, beamX))
-    beamY = math.max(0, math.min(screenHeight - 32, beamY))
-
-    -- Update circle radius based on crank position (0° = large, 180° = small)
-    local crankPos = playdate.getCrankPosition() -- 0 to 359
-
-    -- Map 0°/360° to maxRadius, 180° to minRadius
-    local t = 1 - math.abs((crankPos % 360) / 180 - 1) -- t: 1 at 0°/360°, 0 at 180°
-    beamRadius = minBeamRadius + (maxBeamRadius - minBeamRadius) * t
-
-    -- Draw and update flying objects
-    for i = #flyingObjects, 1, -1 do
-        local obj = flyingObjects[i]
-        obj.size = obj.size + obj.speed
-        gfx.setColor(gfx.kColorWhite)
-        gfx.fillCircleAtPoint(obj.x, obj.y, obj.size)
-
-        -- Check if object is inside the beam
-        local dx = obj.x - beamX
-        local dy = obj.y - beamY
-        local dist = math.sqrt(dx * dx + dy * dy)
-        if dist < beamRadius and beamRadius > obj.size then
-            table.remove(flyingObjects, i)
-            spawnFlyingObject()
-            caught = caught + 1
-            -- Calculate score based on how close beamRadius is to obj.size and how small the object is
-            local s1 = 1
-            if beamRadius ~= maxBeamRadius then
-                s1 = math.floor(1 + (100 - 1) * (1 - (math.abs(beamRadius - obj.size) / (maxBeamRadius - obj.size))))
-            end
-            s1 = math.max(1, math.min(100, s1))
-            -- Bonus for smaller objects: 100 for smallest, 0 for largest
-            local minObjSize = 1
-            local s2 = math.floor(100 * (1 - ((obj.size - minObjSize) / (maxObjectSize - minObjSize))))
-            s2 = math.max(0, math.min(100, s2))
-            local s = s1 + s2
-            score = score + s
-            -- Play sound with pitch based on score (higher score = higher pitch) and volume based on object size (smaller = quieter)
-            local minFreq = 220 -- Hz (A3)
-            local maxFreq = 880 -- Hz (A5)
-            local freq = minFreq + ((s - 1) / 199) * (maxFreq - minFreq) -- s ranges from 1 to 200
-            local minObjSize = 1
-            local norm = (obj.size - minObjSize) / (maxObjectSize - minObjSize)
-            local volume = 0.05 + 0.20 * (norm * norm) -- Squared scaling, min 0.05, max 0.25
-            captureSynth:playNote(freq, volume, 0.5)
-            -- Add a score popup at the object's position
-            table.insert(scorePopups, {
-                x = obj.x,
-                y = obj.y,
-                value = s,
-                time = playdate.getCurrentTimeMilliseconds()
-            })
-        -- Remove and respawn if too big (missed)
-        elseif obj.size > maxObjectSize then
-            table.remove(flyingObjects, i)
-            spawnFlyingObject()
-            missed = missed + 1
-        end
-    end
-
-    -- Draw score popups and remove expired ones
-    local now = playdate.getCurrentTimeMilliseconds()
-    for i = #scorePopups, 1, -1 do
-        local popup = scorePopups[i]
-        if now - popup.time < 1000 then
-            gfx.setImageDrawMode(gfx.kDrawModeFillWhite)
-            gfx.setColor(gfx.kColorWhite)
-            gfx.drawTextAligned("" .. tostring(popup.value), popup.x, popup.y, kTextAlignment.center)
-        else
-            table.remove(scorePopups, i)
-        end
-    end
-
-    -- Show crank alert if crank is docked
-    if playdate.isCrankDocked() then
-        playdate.ui.crankIndicator:draw()
-    end
-
-    ui.drawScore(caught, missed, score)
-
+    scene_manager.update()
+    scene_manager.draw()
     playdate.timer.updateTimers()
+end
+
+function playdate.AButtonDown()
+    scene_manager.AButtonDown()
+end
+
+-- Start with the menu scene
+scene_manager.setScene(menu_scene)
+
+_G.switchToGameScene = function()
+    scene_manager.setScene(game_scene)
 end

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -90,8 +90,8 @@ function game_scene:update()
             local s = s1 + s2
             self.score = self.score + s
             -- Sound
-            local minFreq = 220
-            local maxFreq = 880
+            local minFreq = 220 -- A2 (220 Hz)
+            local maxFreq = 880 -- A4 (880 Hz)
             local freq = minFreq + ((s - 1) / 199) * (maxFreq - minFreq)
             local norm = (obj.size - minObjSize) / (self.maxObjectSize - minObjSize)
             local volume = 0.05 + 0.20 * (norm * norm)

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -1,0 +1,161 @@
+-- scenes/game_scene.lua
+local gfx <const> = playdate.graphics
+local snd = playdate.sound
+local captureSynth = snd.synth.new(snd.kWaveSquare)
+
+local game_scene = {}
+
+function game_scene:enter()
+    -- Initialize or reset game state here
+    self.screenWidth, self.screenHeight = playdate.display.getWidth(), playdate.display.getHeight()
+    self.beamRadius = 20
+    self.beamX, self.beamY = self.screenWidth / 2, self.screenHeight / 2
+    self.minBeamRadius = 5
+    self.maxBeamRadius = 75
+    -- Stars
+    self.numStars = 50
+    self.stars = {}
+    math.randomseed(playdate.getSecondsSinceEpoch())
+    for i = 1, self.numStars do
+        table.insert(self.stars, {
+            x = math.random(0, self.screenWidth),
+            y = math.random(0, self.screenHeight),
+            size = math.random(1, 2)
+        })
+    end
+    -- Flying objects
+    self.flyingObjects = {}
+    self.maxFlyingObjects = 3
+    self.maxObjectSize = self.maxBeamRadius / 3
+    for i = 1, self.maxFlyingObjects do
+        self:spawnFlyingObject()
+    end
+    self.caught = 0
+    self.missed = 0
+    self.score = 0
+    self.scorePopups = {}
+end
+
+function game_scene:spawnFlyingObject()
+    table.insert(self.flyingObjects, {
+        x = math.random(0, self.screenWidth),
+        y = math.random(0, self.screenHeight - 32),
+        size = 1,
+        speed = math.random(1, 3) / 10
+    })
+end
+
+function game_scene:update()
+    -- Movement
+    local moveSpeed = math.max(5, math.floor(self.beamRadius / 5))
+    if playdate.buttonIsPressed(playdate.kButtonUp) then
+        self.beamY = self.beamY - moveSpeed
+    end
+    if playdate.buttonIsPressed(playdate.kButtonDown) then
+        self.beamY = self.beamY + moveSpeed
+    end
+    if playdate.buttonIsPressed(playdate.kButtonLeft) then
+        self.beamX = self.beamX - moveSpeed
+    end
+    if playdate.buttonIsPressed(playdate.kButtonRight) then
+        self.beamX = self.beamX + moveSpeed
+    end
+    self.beamX = math.max(0, math.min(self.screenWidth, self.beamX))
+    self.beamY = math.max(0, math.min(self.screenHeight - 32, self.beamY))
+    -- Crank
+    local crankPos = playdate.getCrankPosition()
+    local t = 1 - math.abs((crankPos % 360) / 180 - 1)
+    self.beamRadius = self.minBeamRadius + (self.maxBeamRadius - self.minBeamRadius) * t
+    -- Flying objects
+    for i = #self.flyingObjects, 1, -1 do
+        local obj = self.flyingObjects[i]
+        obj.size = obj.size + obj.speed
+        -- Check if object is inside the beam and beam is larger than object
+        local dx = obj.x - self.beamX
+        local dy = obj.y - self.beamY
+        local dist = math.sqrt(dx * dx + dy * dy)
+        if dist < self.beamRadius and self.beamRadius > obj.size then
+            table.remove(self.flyingObjects, i)
+            self:spawnFlyingObject()
+            self.caught = self.caught + 1
+            -- Score calculation
+            local s1 = 1
+            if self.beamRadius ~= self.maxBeamRadius then
+                s1 = math.floor(1 + (100 - 1) * (1 - (math.abs(self.beamRadius - obj.size) / (self.maxBeamRadius - obj.size))))
+            end
+            s1 = math.max(1, math.min(100, s1))
+            local minObjSize = 1
+            local s2 = math.floor(100 * (1 - ((obj.size - minObjSize) / (self.maxObjectSize - minObjSize))))
+            s2 = math.max(0, math.min(100, s2))
+            local s = s1 + s2
+            self.score = self.score + s
+            -- Sound
+            local minFreq = 220
+            local maxFreq = 880
+            local freq = minFreq + ((s - 1) / 199) * (maxFreq - minFreq)
+            local norm = (obj.size - minObjSize) / (self.maxObjectSize - minObjSize)
+            local volume = 0.05 + 0.20 * (norm * norm)
+            captureSynth:playNote(freq, volume, 0.5)
+            table.insert(self.scorePopups, {
+                x = obj.x,
+                y = obj.y,
+                value = s,
+                time = playdate.getCurrentTimeMilliseconds()
+            })
+        elseif obj.size > self.maxObjectSize then
+            table.remove(self.flyingObjects, i)
+            self:spawnFlyingObject()
+            self.missed = self.missed + 1
+        end
+    end
+end
+
+function game_scene:draw()
+    gfx.clear(gfx.kColorBlack)
+    -- Stars
+    gfx.setColor(gfx.kColorWhite)
+    local maxOffset = 3
+    local dx = math.max(-maxOffset, math.min(maxOffset, (self.beamX - self.screenWidth/2) * 0.01))
+    local dy = math.max(-maxOffset, math.min(maxOffset, (self.beamY - self.screenHeight/2) * 0.01))
+    for i = 1, #self.stars do
+        local px = self.stars[i].x - dx * self.stars[i].size
+        local py = self.stars[i].y - dy * self.stars[i].size
+        if self.stars[i].size == 1 then
+            gfx.drawPixel(px, py)
+        else
+            gfx.drawLine(px - 2, py, px + 2, py)
+            gfx.drawLine(px, py - 2, px, py + 2)
+        end
+    end
+    -- Beam
+    local cx, cy = math.floor(self.beamX + 0.5), math.floor(self.beamY + 0.5)
+    local innerRadius = math.floor(self.beamRadius + 0.5)
+    local outerRadius = math.floor(self.beamRadius + (self.beamRadius / 10) + 0.5)
+    gfx.drawCircleAtPoint(cx, cy, innerRadius)
+    gfx.drawCircleAtPoint(cx, cy, outerRadius)
+    -- Flying objects
+    for i = 1, #self.flyingObjects do
+        local obj = self.flyingObjects[i]
+        gfx.setColor(gfx.kColorWhite)
+        gfx.fillCircleAtPoint(obj.x, obj.y, obj.size)
+    end
+    -- Score popups
+    local now = playdate.getCurrentTimeMilliseconds()
+    for i = #self.scorePopups, 1, -1 do
+        local popup = self.scorePopups[i]
+        if now - popup.time < 1000 then
+            gfx.setImageDrawMode(gfx.kDrawModeFillWhite)
+            gfx.setColor(gfx.kColorWhite)
+            gfx.drawTextAligned("" .. tostring(popup.value), popup.x, popup.y, kTextAlignment.center)
+        else
+            table.remove(self.scorePopups, i)
+        end
+    end
+    -- Crank alert
+    if playdate.isCrankDocked() then
+        playdate.ui.crankIndicator:draw()
+    end
+    ui.drawScore(self.caught, self.missed, self.score)
+end
+
+return game_scene

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -1,0 +1,32 @@
+-- scenes/menu_scene.lua
+local gfx <const> = playdate.graphics
+local menu_scene = {}
+
+function menu_scene:enter()
+    -- Called when entering the menu scene
+end
+
+function menu_scene:update()
+    -- Nothing to update for static menu
+end
+
+function menu_scene:draw()
+    gfx.setColor(gfx.kColorBlack)
+    gfx.fillRect(0, 0, 400, 240)
+    gfx.setImageDrawMode(gfx.kDrawModeFillWhite)
+    gfx.setColor(gfx.kColorWhite)
+    
+    gfx.setFont(gfx.getSystemFont())
+    gfx.drawTextAligned("SPACE JUNK", 200, 80, kTextAlignment.center)
+    gfx.setFont(ui.cyberballFont)
+    gfx.drawTextAligned("PRESS A TO START", 200, 140, kTextAlignment.center)
+end
+
+function menu_scene:AButtonDown()
+    -- Switch to game scene
+    if _G.switchToGameScene then
+        _G.switchToGameScene()
+    end
+end
+
+return menu_scene

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -1,0 +1,31 @@
+-- scenes/scene_manager.lua
+local scene_manager = {}
+
+local currentScene = nil
+
+function scene_manager.setScene(scene)
+    currentScene = scene
+    if currentScene and currentScene.enter then
+        currentScene:enter()
+    end
+end
+
+function scene_manager.update()
+    if currentScene and currentScene.update then
+        currentScene:update()
+    end
+end
+
+function scene_manager.draw()
+    if currentScene and currentScene.draw then
+        currentScene:draw()
+    end
+end
+
+function scene_manager.AButtonDown()
+    if currentScene and currentScene.AButtonDown then
+        currentScene:AButtonDown()
+    end
+end
+
+return scene_manager

--- a/Source/ui.lua
+++ b/Source/ui.lua
@@ -22,5 +22,6 @@ local function drawScore(caught, missed, score)
 end
 
 return {
-    drawScore = drawScore
+    drawScore = drawScore,
+    cyberballFont = cyberballFont
 }


### PR DESCRIPTION
This pull request refactors the game code to introduce a scene-based architecture, improving modularity and maintainability. The changes include the creation of a `scene_manager` and separate files for the game and menu scenes, along with updates to the main game loop to integrate this new structure.

### Scene-based Architecture Refactor:
* [`Source/main.lua`](diffhunk://#diff-d65dc00a302e1ad41e7b5c6e975738d1da5fbc3de13d02d9de6e780b65325791L7-R26): Replaced the monolithic game logic with a `scene_manager` to handle scene transitions. The game now starts with the menu scene and switches to the game scene when the "A" button is pressed.
* [`Source/scenes/scene_manager.lua`](diffhunk://#diff-b67779d62b57d3563dcead007afe93e205ac54856ee65243f6099a942e9cff85R1-R31): Added a `scene_manager` module to manage the current scene, delegating `update`, `draw`, and `AButtonDown` calls to the active scene.

### Game Scene Implementation:
* [`Source/scenes/game_scene.lua`](diffhunk://#diff-beaf7f703ac515e1c02e5f49e3fdca12df4aaa30e110b6c69eb7c96a3e1bd2f9R1-R161): Moved the game logic (e.g., beam movement, flying objects, scoring) into a dedicated `game_scene` module, encapsulating all game-specific functionality.

### Menu Scene Implementation:
* [`Source/scenes/menu_scene.lua`](diffhunk://#diff-5a2f78ace838f8e2bd6ce43af0dfc1c7ea5a09f836ffa02370d5ca0ca7d2f178R1-R32): Added a `menu_scene` module for the start menu, displaying the game title and a prompt to press "A" to start.

### UI Enhancements:
* [`Source/ui.lua`](diffhunk://#diff-c845180126d2e68b0d6cc254312caa5a23e1ad57d7f7dcac1ae9d011eb51938bL25-R26): Exposed a `cyberballFont` for use in the menu scene's text rendering.