### PR TITLE
Menu transitions

### DIFF
--- a/Source/graphics/starfield.lua
+++ b/Source/graphics/starfield.lua
@@ -29,7 +29,18 @@ function Starfield:setParallaxOffset(px, py)
     self.parallaxY = py or 0
 end
 
-function Starfield:draw(centerX, centerY, screenWidth, screenHeight, parallaxX)
+function Starfield:scrollParallaxY(dy, screenHeight)
+    local maxY = ((self.height or ((screenHeight or 240) * 3)) - (screenHeight or 240)) / 2
+    local newY = (self.parallaxY or 0) + dy
+    if maxY > 0 then
+        newY = math.max(-maxY, math.min(newY, maxY))
+    else
+        newY = 0
+    end
+    self:setParallaxOffset(self.parallaxX or 0, newY)
+end
+
+function Starfield:draw(centerX, centerY, screenWidth, screenHeight, parallaxX, parallaxY)
     gfx.setColor(gfx.kColorWhite)
     local maxOffset = 3
     local dx, dy = 0, 0
@@ -37,11 +48,8 @@ function Starfield:draw(centerX, centerY, screenWidth, screenHeight, parallaxX)
         dx = math.max(-maxOffset, math.min(maxOffset, (centerX - screenWidth/2) * 0.01))
         dy = math.max(-maxOffset, math.min(maxOffset, (centerY - screenHeight/2) * 0.01))
     end
-    dx = dx + (self.parallaxX or 0)
-    dy = dy + (self.parallaxY or 0)
-    if parallaxX then
-        dx = dx + parallaxX
-    end
+    dx = dx + (parallaxX or self.parallaxX or 0)
+    dy = dy + (parallaxY or self.parallaxY or 0)
     for i = 1, #self.stars do
         local px = self.stars[i].x - dx * self.stars[i].size
         local py = self.stars[i].y - dy * (self.stars[i].size == 1 and 1 or 1.5)

--- a/Source/graphics/starfield.lua
+++ b/Source/graphics/starfield.lua
@@ -6,10 +6,13 @@ local Starfield = {}
 Starfield.__index = Starfield
 
 local NUM_STARS = 150
+local GRID_SIZE = 3
+local DEFAULT_SCREEN_WIDTH = 400
+local DEFAULT_SCREEN_HEIGHT = 240
 
 function Starfield.new()
-    local width = (_G.SCREEN_WIDTH or 400) * 3
-    local height = (_G.SCREEN_HEIGHT or 240) * 3
+    local width = (_G.SCREEN_WIDTH or DEFAULT_SCREEN_WIDTH) * GRID_SIZE
+    local height = (_G.SCREEN_HEIGHT or DEFAULT_SCREEN_HEIGHT) * GRID_SIZE
     local self = setmetatable({}, Starfield)
     self.width = width
     self.height = height

--- a/Source/graphics/starfield.lua
+++ b/Source/graphics/starfield.lua
@@ -5,11 +5,15 @@ local gfx <const> = playdate.graphics
 local Starfield = {}
 Starfield.__index = Starfield
 
-function Starfield.new(width, height, numStars)
+local NUM_STARS = 150
+
+function Starfield.new()
+    local width = (_G.SCREEN_WIDTH or 400) * 3
+    local height = (_G.SCREEN_HEIGHT or 240) * 3
     local self = setmetatable({}, Starfield)
     self.width = width
     self.height = height
-    self.numStars = numStars or 50
+    self.numStars = NUM_STARS
     self.stars = {}
     self.parallaxX = 0
     self.parallaxY = 0

--- a/Source/graphics/starfield.lua
+++ b/Source/graphics/starfield.lua
@@ -11,6 +11,8 @@ function Starfield.new(width, height, numStars)
     self.height = height
     self.numStars = numStars or 50
     self.stars = {}
+    self.parallaxX = 0
+    self.parallaxY = 0
     math.randomseed(playdate.getSecondsSinceEpoch())
     for i = 1, self.numStars do
         table.insert(self.stars, {
@@ -22,13 +24,12 @@ function Starfield.new(width, height, numStars)
     return self
 end
 
--- Add this method to allow external parallax offset control
 function Starfield:setParallaxOffset(px, py)
     self.parallaxX = px or 0
     self.parallaxY = py or 0
 end
 
-function Starfield:draw(centerX, centerY, screenWidth, screenHeight)
+function Starfield:draw(centerX, centerY, screenWidth, screenHeight, parallaxX)
     gfx.setColor(gfx.kColorWhite)
     local maxOffset = 3
     local dx, dy = 0, 0
@@ -36,9 +37,11 @@ function Starfield:draw(centerX, centerY, screenWidth, screenHeight)
         dx = math.max(-maxOffset, math.min(maxOffset, (centerX - screenWidth/2) * 0.01))
         dy = math.max(-maxOffset, math.min(maxOffset, (centerY - screenHeight/2) * 0.01))
     end
-    -- Add parallax offsets if set
     dx = dx + (self.parallaxX or 0)
     dy = dy + (self.parallaxY or 0)
+    if parallaxX then
+        dx = dx + parallaxX
+    end
     for i = 1, #self.stars do
         local px = self.stars[i].x - dx * self.stars[i].size
         local py = self.stars[i].y - dy * (self.stars[i].size == 1 and 1 or 1.5)

--- a/Source/graphics/starfield.lua
+++ b/Source/graphics/starfield.lua
@@ -56,6 +56,7 @@ function Starfield:draw(centerX, centerY, screenWidth, screenHeight, parallaxX, 
         if self.stars[i].size == 1 then
             gfx.drawPixel(px, py)
         else
+            gfx.setLineWidth(1)
             gfx.drawLine(px - 2, py, px + 2, py)
             gfx.drawLine(px, py - 2, px, py + 2)
         end

--- a/Source/main.lua
+++ b/Source/main.lua
@@ -40,6 +40,15 @@ local menu_scene = import "scenes/menu_scene"
 local game_scene = import "scenes/game_scene"
 local score_scene = import "scenes/score_scene"
 local highscore_scene = import "scenes/highscore_scene.lua"
+local slide_transition_scene = import "scenes/slide_transition_scene.lua"
+
+-- Make scene_manager global for transition scene usage
+_G.scene_manager = scene_manager
+-- Make slide_transition_scene global for use in menu_scene
+_G.slide_transition_scene = slide_transition_scene
+-- Make menu_scene and highscore_scene global for use in slide_transition_scene
+_G.menu_scene = menu_scene
+_G.highscore_scene = highscore_scene
 
 function playdate.update()
     scene_manager.update()

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -5,7 +5,7 @@ local captureSynth = snd.synth.new(snd.kWaveSquare)
 local game_scene = {}
 
 -- Constants for game configuration and layout
-local GAME_DURATION_MS = 60 * 1000 -- 60 seconds in milliseconds
+local GAME_DURATION_MS = 2 * 1000 -- 60 seconds in milliseconds
 local INITIAL_BEAM_RADIUS = 20
 local MIN_BEAM_RADIUS = 10
 local MAX_BEAM_RADIUS = 75

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -79,8 +79,10 @@ function game_scene:enter()
         local width = (_G.SCREEN_WIDTH or 400)
         local height = (_G.SCREEN_HEIGHT or 240)
         if self.starfield and self.starfield.draw then
-            -- Draw the seamless background
-            self.starfield:draw(baseX, baseY, 3*width, height)
+            -- Calculate gameplay parallax based on beam position
+            local px = (self.beamX - width/2) * 0.02
+            local py = (self.beamY - height/2) * 0.02
+            self.starfield:draw(baseX, baseY, 3*width, height, (self.starfield.parallaxX or 0) + px, (self.starfield.parallaxY or 0) + py)
         end
         self.scorePopups:draw()
     end
@@ -215,15 +217,6 @@ function game_scene:update()
     local crankPos = playdate.getCrankPosition()
     local t = 1 - math.abs((crankPos % 360) / 180 - 1)
     self.beamRadius = self.minBeamRadius + (self.maxBeamRadius - self.minBeamRadius) * t
-
-    -- Parallax starfield based on beam position
-    if self.starfield and self.starfield.setParallaxOffset then
-        local width = _G.SCREEN_WIDTH or 400
-        local height = _G.SCREEN_HEIGHT or 240
-        local px = (self.beamX - width/2) * 0.02 -- less parallax
-        local py = (self.beamY - height/2) * 0.02
-        self.starfield:setParallaxOffset(px, py)
-    end
 
     -- Flying objects (caught)
     for i = #self.flyingObjectSpawner.flyingObjects, 1, -1 do

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -47,22 +47,9 @@ function game_scene:enter()
         self.bgMusicPlayer = nil
     end
 
-    -- Stars
+    -- Use the globally initialized starfield and preserve its offset
     self.starfield = _G.sharedStarfield
-    if self.starfield and self.starfield.setParallaxOffset then
-        self.starfield:setParallaxOffset(0, 0)
-    end
-    -- Draw the starfield once to the background when entering the scene
-    if self.bgSprite then
-        self.bgSprite.draw = function(_)
-            gfx.clear(gfx.kColorBlack)
-            if self.starfield and self.starfield.draw then
-                -- Only draw the starfield once, with the current parallax offset
-                self.starfield:draw((_G.SCREEN_WIDTH or 400)/2, (_G.SCREEN_HEIGHT or 240)/2, 3*(_G.SCREEN_WIDTH or 400), (_G.SCREEN_HEIGHT or 240))
-            end
-            self.scorePopups:draw()
-        end
-    end
+    -- Do NOT reset starfield parallax here; preserve position between scenes
 
     -- Flying objects
     self.flyingObjectImgs = _G.spriteLoader.tableLoad()

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -47,9 +47,8 @@ function game_scene:enter()
         self.bgMusicPlayer = nil
     end
 
-    -- Use the globally initialized starfield and preserve its offset
+    -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
-    -- Do NOT reset starfield parallax here; preserve position between scenes
 
     -- Flying objects
     self.flyingObjectImgs = _G.spriteLoader.tableLoad()

--- a/Source/scenes/highscore_scene.lua
+++ b/Source/scenes/highscore_scene.lua
@@ -16,12 +16,11 @@ local RESET_CONFIRM2_Y = 156
 local RESET_MSG_Y = 136
 
 function highscore_scene:enter()
-    if _G.sharedStarfield then
-        self.starfield = _G.sharedStarfield
-    else
-        self.starfield = _G.Starfield.new(_G.SCREEN_WIDTH, _G.SCREEN_HEIGHT, 50)
-        _G.sharedStarfield = self.starfield
+    -- Only create a new starfield if one does not already exist
+    if not _G.sharedStarfield then
+        _G.sharedStarfield = _G.Starfield.new((_G.SCREEN_WIDTH or 400) * 3, _G.SCREEN_HEIGHT or 240, 150)
     end
+    self.starfield = _G.sharedStarfield
     self.scores = _G.HighScores and _G.HighScores.load() or {}
     self.scrollOffset = 0
     self.maxVisible = 5
@@ -30,57 +29,68 @@ function highscore_scene:enter()
     self.listX = 200
     self.listH = self.maxVisible * self.scoreHeight
     self.maxScroll = math.max(0, (#self.scores - self.maxVisible))
+    -- Do NOT set starfield vertical parallax here; let update() handle it for smoothness
 end
 
-function highscore_scene:draw()
+-- Add support for drawing at an x offset for transition animations
+function highscore_scene:draw(xOffset, hideInstructions)
+    xOffset = xOffset or 0
+    -- Defensive: ensure all required fields are set
+    local width = _G.SCREEN_WIDTH or 400
+    local height = _G.SCREEN_HEIGHT or 240
+    local listW = LIST_W or 180
+    local listH = (self.maxVisible and self.scoreHeight) and (self.maxVisible * self.scoreHeight - 2) or 148
+    local listX = LIST_X or 200
+    local listY0 = LIST_Y0 or 80
+    local listRectYOffset = LIST_RECT_Y_OFFSET or -4
+    local titleX = TITLE_X or 200
+    local titleY = TITLE_Y or 40
+    local instrLeftX = INSTR_LEFT_X or 0
+    local instrRightX = INSTR_RIGHT_X or 400
+    local instrY = INSTR_Y or 220
+    local statsFont = ui and ui.altText_font or gfx.getFont()
+    local scores = self.scores or {}
+    local maxVisible = self.maxVisible or 5
+    local scoreHeight = self.scoreHeight or 30
+    local scrollOffset = self.scrollOffset or 0
+    local maxScroll = self.maxScroll or 0
+    local hideThresholdY = titleY + 22
+    local yOffset = -(scrollOffset % 1) * scoreHeight
     gfx.setImageDrawMode(gfx.kDrawModeCopy)
+    -- Remove any full-screen black fill or color set at the start
+    -- Only draw black rectangles for UI elements (like the high score list background), not the whole screen
+    gfx.setFont(statsFont)
+    local listRectX = listX - listW/2 + xOffset
+    local listRectY = listY0 + listRectYOffset
     gfx.setColor(gfx.kColorBlack)
-    gfx.fillRect(0, 0, _G.SCREEN_WIDTH, _G.SCREEN_HEIGHT)
-    -- Parallax starfield: move stars vertically based on scrollOffset
-    local parallaxY = 0
-    if self.scrollOffset and self.maxScroll and self.maxScroll > 0 then
-        -- Map scrollOffset (0..maxScroll) to a parallax range, e.g., -16 to +16 px
-        parallaxY = (self.scrollOffset / self.maxScroll - 0.5) * 32 -- center at 0
-    end
-    if self.starfield then
-        self.starfield:draw(_G.SCREEN_WIDTH/2, _G.SCREEN_HEIGHT/2 + parallaxY, _G.SCREEN_WIDTH, _G.SCREEN_HEIGHT, parallaxY)
-    end
+    gfx.fillRect(listRectX, listRectY, listW, listH)
     gfx.setImageDrawMode(gfx.kDrawModeFillWhite)
-    -- Draw black rectangle and banner for the HIGH SCORES title using drawBanner
-    _G.drawBanner.draw("HIGH SCORES", TITLE_X, TITLE_Y, ui.titleText_font)
-    gfx.setFont(ui.altText_font)
-    -- Draw one black rectangle behind all high scores (manual, not using drawBanner)
-    local listRectW, listRectH = LIST_W, self.maxVisible * self.scoreHeight - 2
-    local listRectX = LIST_X - listRectW/2
-    local listRectY = LIST_Y0 + LIST_RECT_Y_OFFSET
-    gfx.setColor(gfx.kColorBlack)
-    gfx.fillRect(listRectX, listRectY, listRectW, listRectH)
-    -- Draw 5 visible scores, smoothly scrolled, initials then score
-    gfx.setImageDrawMode(gfx.kDrawModeFillWhite) -- Ensure text is drawn in white
     gfx.setColor(gfx.kColorWhite)
-    local firstIdx = math.floor(self.scrollOffset) + 1
-    local yOffset = -(self.scrollOffset % 1) * self.scoreHeight
-    local hideThresholdY = TITLE_Y + 22 -- Hide scores above this y (just below title)
-    for i = 0, self.maxVisible - 1 do
+    local firstIdx = math.floor(scrollOffset) + 1
+    for i = 0, maxVisible - 1 do
         local scoreIdx = firstIdx + i
-        local entry = self.scores[scoreIdx]
+        local entry = scores[scoreIdx]
         if entry and entry.score and entry.initials then
-            local y = LIST_Y0 + i * self.scoreHeight + yOffset
+            local y = listY0 + i * scoreHeight + yOffset
             if y > hideThresholdY then
                 local initials = entry.initials or "   "
                 local score = entry.score or 0
-                gfx.drawTextAligned(string.format("%s  %d", initials, score), LIST_X, y, kTextAlignment.center)
+                gfx.drawTextAligned(string.format("%s  %d", initials, score), listX + xOffset, y, kTextAlignment.center)
             end
         end
     end
-    gfx.setImageDrawMode(gfx.kDrawModeCopy) -- Reset draw mode after text
-    -- Draw bottom instructions: left and right aligned, with black rectangles using drawBanner
-    _G.drawBanner.drawAligned("< Back to Menu", INSTR_LEFT_X, INSTR_Y, kTextAlignment.left, ui.altText_font)
-    _G.drawBanner.drawAligned("Crank: Show more scores!", INSTR_RIGHT_X, INSTR_Y, kTextAlignment.right, ui.altText_font)
-    -- Draw reset confirmation or reset message if needed
-    if self.confirmingReset then
+    gfx.setImageDrawMode(gfx.kDrawModeCopy)
+    -- Draw the HIGH SCORES banner
+    if _G.drawBanner and _G.drawBanner.draw then
+        _G.drawBanner.draw("HIGH SCORES", (TITLE_X or 200) + xOffset, (TITLE_Y or 40), ui and ui.titleText_font or nil)
+    end
+    if not hideInstructions and _G.drawBanner and _G.drawBanner.drawAligned then
+        _G.drawBanner.drawAligned("< Back to Menu", instrLeftX + xOffset, instrY, kTextAlignment.left, statsFont)
+        _G.drawBanner.drawAligned("Crank: Show more scores!", instrRightX + xOffset, instrY, kTextAlignment.right, statsFont)
+    end
+    if self.confirmingReset and type(drawResetConfirmation) == "function" then
         drawResetConfirmation()
-    elseif self.showResetMsg and self.showResetMsg > 0 then
+    elseif self.showResetMsg and self.showResetMsg > 0 and type(drawResetMessage) == "function" then
         drawResetMessage()
     end
 end
@@ -104,6 +114,7 @@ function highscore_scene:update()
         self.scrollOffset = math.max(0, math.min(self.scrollOffset, self.maxScroll))
     end
     -- Always update starfield parallax, not just on crank
+    --[[
     if self.starfield and self.starfield.setParallaxOffset then
         local parallaxY = 0
         if self.maxScroll > 0 then
@@ -111,7 +122,7 @@ function highscore_scene:update()
         end
         self.starfield:setParallaxOffset(0, parallaxY)
     end
-    
+    ]]
     -- Reset high scores: hold A+B for 2 seconds, then confirm
     self.resetTimer = self.resetTimer or 0
     if not self.confirmingReset then
@@ -157,7 +168,12 @@ function highscore_scene:leftButtonDown()
         self.resetTimer = 0
         return
     end
-    if _G.switchToMenuScene then _G.switchToMenuScene() end
+    -- Trigger slide transition back to menu (right-to-left)
+    if _G.scene_manager and _G.slide_transition_scene then
+        _G.scene_manager.setScene(_G.slide_transition_scene, -1)
+    else
+        if _G.switchToMenuScene then _G.switchToMenuScene() end
+    end
 end
 
 function highscore_scene:BButtonDown()

--- a/Source/scenes/highscore_scene.lua
+++ b/Source/scenes/highscore_scene.lua
@@ -4,7 +4,7 @@ local highscore_scene = {}
 -- Constants for layout and spacing
 local TITLE_Y = 40
 local TITLE_X = 200
-local LIST_W = 180
+local LIST_W = 90
 local LIST_X = 200
 local LIST_Y0 = 80
 local LIST_RECT_Y_OFFSET = -4
@@ -26,6 +26,14 @@ function highscore_scene:enter()
     self.listX = 200
     self.listH = self.maxVisible * self.scoreHeight
     self.maxScroll = math.max(0, (#self.scores - self.maxVisible))
+    -- Center the starfield vertically if not already centered (prevents snapping if returning from game)
+    if self.starfield and self.starfield.height and self.starfield.screenH then
+        local centerY = (self.starfield.height - self.starfield.screenH) / 2
+        if not self.starfield._parallaxYInitialized then
+            self.starfield.parallaxY = centerY
+            self.starfield._parallaxYInitialized = true
+        end
+    end
     -- Do NOT set starfield vertical parallax here; let update() handle it for smoothness
 end
 

--- a/Source/scenes/highscore_scene.lua
+++ b/Source/scenes/highscore_scene.lua
@@ -15,20 +15,25 @@ local RESET_CONFIRM_Y = 136
 local RESET_CONFIRM2_Y = 156
 local RESET_MSG_Y = 136
 
+-- Constants for starfield and layout
+local STARFIELD_CENTER_Y = 120
+local MAX_VISIBLE = 5
+local SCORE_HEIGHT = 30
+
 function highscore_scene:enter()
     -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
     self.scores = _G.HighScores and _G.HighScores.load() or {}
     self.scrollOffset = 0
-    self.maxVisible = 5
-    self.scoreHeight = 30
-    self.listY0 = 80
-    self.listX = 200
+    self.maxVisible = MAX_VISIBLE
+    self.scoreHeight = SCORE_HEIGHT
+    self.listY0 = LIST_Y0
+    self.listX = LIST_X
     self.listH = self.maxVisible * self.scoreHeight
     self.maxScroll = math.max(0, (#self.scores - self.maxVisible))
-    -- Center the starfield vertically at 120px offset if not already set
+    -- Center the starfield vertically at STARFIELD_CENTER_Y offset if not already set
     if self.starfield and self.starfield.height then
-        local centerY = 120
+        local centerY = STARFIELD_CENTER_Y
         if not self.starfield._parallaxYInitialized then
             self.starfield.parallaxY = centerY
             self.starfield._parallaxYInitialized = true

--- a/Source/scenes/highscore_scene.lua
+++ b/Source/scenes/highscore_scene.lua
@@ -26,9 +26,9 @@ function highscore_scene:enter()
     self.listX = 200
     self.listH = self.maxVisible * self.scoreHeight
     self.maxScroll = math.max(0, (#self.scores - self.maxVisible))
-    -- Center the starfield vertically if not already centered (prevents snapping if returning from game)
-    if self.starfield and self.starfield.height and self.starfield.screenH then
-        local centerY = (self.starfield.height - self.starfield.screenH) / 2
+    -- Center the starfield vertically at 120px offset if not already set
+    if self.starfield and self.starfield.height then
+        local centerY = 120
         if not self.starfield._parallaxYInitialized then
             self.starfield.parallaxY = centerY
             self.starfield._parallaxYInitialized = true

--- a/Source/scenes/highscore_scene.lua
+++ b/Source/scenes/highscore_scene.lua
@@ -16,10 +16,7 @@ local RESET_CONFIRM2_Y = 156
 local RESET_MSG_Y = 136
 
 function highscore_scene:enter()
-    -- Only create a new starfield if one does not already exist
-    if not _G.sharedStarfield then
-        _G.sharedStarfield = _G.Starfield.new((_G.SCREEN_WIDTH or 400) * 3, _G.SCREEN_HEIGHT or 240, 150)
-    end
+    -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
     self.scores = _G.HighScores and _G.HighScores.load() or {}
     self.scrollOffset = 0
@@ -107,22 +104,12 @@ function drawResetMessage()
 end
 
 function highscore_scene:update()
-    -- Crank-based scrolling
+    -- Crank-based scrolling for the score list
     local crankChange = playdate.getCrankChange()
     if math.abs(crankChange) > 0 then
         self.scrollOffset = self.scrollOffset - crankChange * 0.04
         self.scrollOffset = math.max(0, math.min(self.scrollOffset, self.maxScroll))
     end
-    -- Always update starfield parallax, not just on crank
-    --[[
-    if self.starfield and self.starfield.setParallaxOffset then
-        local parallaxY = 0
-        if self.maxScroll > 0 then
-            parallaxY = (self.scrollOffset / self.maxScroll - 0.5) * 32
-        end
-        self.starfield:setParallaxOffset(0, parallaxY)
-    end
-    ]]
     -- Reset high scores: hold A+B for 2 seconds, then confirm
     self.resetTimer = self.resetTimer or 0
     if not self.confirmingReset then

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -10,22 +10,15 @@ local INSTR_Y = 220
 local A_CHAR_INDEX = 9 -- position of 'A' in the string (1-based)
 
 function menu_scene:enter()
-    -- Called when entering the menu scene
-    if not _G.sharedStarfield then
-        _G.sharedStarfield = _G.Starfield.new((_G.SCREEN_WIDTH or 400) * 3, _G.SCREEN_HEIGHT or 240, 150)
-    end
+    -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
-    -- Reset starfield vertical parallax so it starts at the top
-    if self.starfield and self.starfield.setParallaxOffset then
-        self.starfield:setParallaxOffset(self.starfield.parallaxX or 0, 0)
-    end
 end
 
 function menu_scene:leave()
 end
 
 function menu_scene:update()
-    -- Nothing to update for static menu
+    -- No per-scene parallax logic needed; handled globally
 end
 
 -- Add support for drawing at an x offset for transition animations

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -12,6 +12,14 @@ local A_CHAR_INDEX = 9 -- position of 'A' in the string (1-based)
 function menu_scene:enter()
     -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
+    -- Center the starfield vertically if not already centered (prevents snapping if returning from game)
+    if self.starfield and self.starfield.height and self.starfield.screenH then
+        local centerY = (self.starfield.height - self.starfield.screenH) / 2
+        if not self.starfield._parallaxYInitialized then
+            self.starfield.parallaxY = centerY
+            self.starfield._parallaxYInitialized = true
+        end
+    end
 end
 
 function menu_scene:leave()

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -12,9 +12,9 @@ local A_CHAR_INDEX = 9 -- position of 'A' in the string (1-based)
 function menu_scene:enter()
     -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
-    -- Center the starfield vertically if not already centered (prevents snapping if returning from game)
-    if self.starfield and self.starfield.height and self.starfield.screenH then
-        local centerY = (self.starfield.height - self.starfield.screenH) / 2
+    -- Center the starfield vertically at 120px offset if not already set
+    if self.starfield and self.starfield.height then
+        local centerY = 120
         if not self.starfield._parallaxYInitialized then
             self.starfield.parallaxY = centerY
             self.starfield._parallaxYInitialized = true

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -11,8 +11,14 @@ local A_CHAR_INDEX = 9 -- position of 'A' in the string (1-based)
 
 function menu_scene:enter()
     -- Called when entering the menu scene
-    _G.sharedStarfield = _G.Starfield.new(_G.SCREEN_WIDTH, _G.SCREEN_HEIGHT, 50)
+    if not _G.sharedStarfield then
+        _G.sharedStarfield = _G.Starfield.new((_G.SCREEN_WIDTH or 400) * 3, _G.SCREEN_HEIGHT or 240, 150)
+    end
     self.starfield = _G.sharedStarfield
+    -- Reset starfield vertical parallax so it starts at the top
+    if self.starfield and self.starfield.setParallaxOffset then
+        self.starfield:setParallaxOffset(self.starfield.parallaxX or 0, 0)
+    end
 end
 
 function menu_scene:leave()
@@ -22,36 +28,40 @@ function menu_scene:update()
     -- Nothing to update for static menu
 end
 
-function menu_scene:draw()
-    -- Fill background and draw starfield
+-- Add support for drawing at an x offset for transition animations
+function menu_scene:draw(xOffset, hideInstructions)
+    xOffset = xOffset or 0
+    local width = _G.SCREEN_WIDTH or 400
+    local height = _G.SCREEN_HEIGHT or 240
+    local titleX = TITLE_X or 200
+    local titleY = TITLE_Y or 80
+    local startSubtitleY = START_SUBTITLE_Y or 140
+    local instrRightX = INSTR_RIGHT_X or 400
+    local instrY = INSTR_Y or 220
+    local aCharIndex = A_CHAR_INDEX or 9
+    local statsFont = ui and ui.altText_font or gfx.getFont()
     gfx.setImageDrawMode(gfx.kDrawModeCopy)
     gfx.setColor(gfx.kColorBlack)
-    gfx.fillRect(0, 0, _G.SCREEN_WIDTH, _G.SCREEN_HEIGHT)
-    if self.starfield then
-        self.starfield:draw(_G.SCREEN_WIDTH/2, _G.SCREEN_HEIGHT/2, _G.SCREEN_WIDTH, _G.SCREEN_HEIGHT)
+    if _G.drawBanner and _G.drawBanner.draw then
+        _G.drawBanner.draw("SPACE JUNK", titleX + xOffset, titleY, ui and ui.titleText_font or nil)
     end
-
-    -- Title background and text
-    _G.drawBanner.draw("SPACE JUNK", TITLE_X, TITLE_Y, ui.titleText_font)
-
-    -- Start subtitle background and text
     local startSubtitle = "PRESS   A   TO START"
-    _G.drawBanner.draw(startSubtitle, TITLE_X, START_SUBTITLE_Y, ui.altText_font)
-
-    -- Draw a circle around the 'A' in the start subtitle (robust to font/spacing)
-    local prefix = string.sub(startSubtitle, 1, A_CHAR_INDEX - 1)
+    if _G.drawBanner and _G.drawBanner.draw then
+        _G.drawBanner.draw(startSubtitle, titleX + xOffset, startSubtitleY, statsFont)
+    end
+    local prefix = string.sub(startSubtitle, 1, aCharIndex - 1)
     local prefixW, _ = gfx.getTextSize(prefix)
     local aW, _ = gfx.getTextSize("A")
     local startSubtitleW, _ = gfx.getTextSize(startSubtitle)
-    local aX = TITLE_X - (startSubtitleW / 2) + prefixW + aW / 2
-    local aY = START_SUBTITLE_Y + ui.altText_font:getHeight() / 2
+    local aX = titleX - (startSubtitleW / 2) + prefixW + aW / 2 + xOffset
+    local aY = startSubtitleY + (statsFont and statsFont.getHeight and statsFont:getHeight() or 0) / 2
     gfx.setColor(gfx.kColorWhite)
     gfx.setLineWidth(2)
-    gfx.drawCircleAtPoint(aX, aY, aW) 
-
-    -- High score subtitle at the bottom
-    _G.drawBanner.drawAligned("High Scores >", INSTR_RIGHT_X, INSTR_Y,  kTextAlignment.right, ui.altText_font)
-    gfx.setImageDrawMode(gfx.kDrawModeCopy) -- Reset draw mode after all drawing
+    gfx.drawCircleAtPoint(aX, aY, aW)
+    if not hideInstructions and _G.drawBanner and _G.drawBanner.drawAligned then
+        _G.drawBanner.drawAligned("High Scores >", instrRightX + xOffset, instrY,  kTextAlignment.right, statsFont)
+    end
+    gfx.setImageDrawMode(gfx.kDrawModeCopy)
 end
 
 function menu_scene:AButtonDown()
@@ -62,9 +72,8 @@ function menu_scene:AButtonDown()
 end
 
 function menu_scene:rightButtonDown()
-    if _G.switchToHighScoreScene then
-        _G.switchToHighScoreScene()
-    end
+    -- Trigger slide transition instead of switching directly
+    _G.scene_manager.setScene(_G.slide_transition_scene, 1)
 end
 
 return menu_scene

--- a/Source/scenes/menu_scene.lua
+++ b/Source/scenes/menu_scene.lua
@@ -1,6 +1,9 @@
 local gfx <const> = playdate.graphics
 local menu_scene = {}
 
+-- Constants for starfield and layout
+local STARFIELD_CENTER_Y = 120
+
 -- Constants for layout and spacing
 local TITLE_Y = 80
 local TITLE_X = 200
@@ -12,9 +15,9 @@ local A_CHAR_INDEX = 9 -- position of 'A' in the string (1-based)
 function menu_scene:enter()
     -- Use the globally initialized starfield
     self.starfield = _G.sharedStarfield
-    -- Center the starfield vertically at 120px offset if not already set
+    -- Center the starfield vertically at STARFIELD_CENTER_Y offset if not already set
     if self.starfield and self.starfield.height then
-        local centerY = 120
+        local centerY = STARFIELD_CENTER_Y
         if not self.starfield._parallaxYInitialized then
             self.starfield.parallaxY = centerY
             self.starfield._parallaxYInitialized = true

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -5,12 +5,24 @@ local scene_manager = {}
 
 local currentScene = nil
 
+-- Initialize the global starfield (3x3 screens, centered)
+local function ensureStarfield()
+    local width = _G.SCREEN_WIDTH or 400
+    local height = _G.SCREEN_HEIGHT or 240
+    if not _G.sharedStarfield then
+        _G.sharedStarfield = _G.Starfield.new(width * 3, height * 3, 150)
+        _G.sharedStarfield.parallaxX = 0
+        _G.sharedStarfield.parallaxY = 0
+    end
+end
+
 function scene_manager.clear()
     playdate.graphics.sprite.removeAll()
     if _G.ui and _G.ui.reset then _G.ui.reset() end
 end
 
 function scene_manager.setScene(scene, ...)
+    ensureStarfield()
     scene_manager.clear()
     if currentScene and currentScene.leave then
         currentScene:leave()
@@ -22,6 +34,18 @@ function scene_manager.setScene(scene, ...)
 end
 
 function scene_manager.update()
+    -- Centralize crank-based Y parallax for menu and highscore scenes
+    if (currentScene == _G.menu_scene or currentScene == _G.highscore_scene) and _G.sharedStarfield then
+        local crankChange = playdate.getCrankChange()
+        if math.abs(crankChange) > 0 then
+            local height = _G.SCREEN_HEIGHT or 240
+            local maxOffset = height -- 240 for 240px screen
+            local newY = (_G.sharedStarfield.parallaxY or 0) - crankChange * 0.5
+            if newY < -maxOffset then newY = -maxOffset end
+            if newY > maxOffset then newY = maxOffset end
+            _G.sharedStarfield.parallaxY = newY
+        end
+    end
     if currentScene and currentScene.update then
         currentScene:update()
     end
@@ -40,8 +64,10 @@ function scene_manager.draw()
             offsetX = 2 * width
         end
         if _G.sharedStarfield and _G.sharedStarfield.draw then
-            _G.sharedStarfield:draw(width/2 + offsetX, height/2, 3 * width, height)
+            _G.sharedStarfield:draw(width/2 + offsetX, height/2, 3 * width, height, 0, _G.sharedStarfield.parallaxY or 0)
         end
+        -- Print debug: show current starfield parallaxY
+        print("Starfield Y: " .. tostring(_G.sharedStarfield and _G.sharedStarfield.parallaxY or "nil"))
     end
     if currentScene and currentScene.draw then
         currentScene:draw()

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -12,7 +12,7 @@ local function ensureStarfield()
     if not _G.sharedStarfield then
         _G.sharedStarfield = _G.Starfield.new(width * 3, height * 3, 150)
         _G.sharedStarfield.parallaxX = 0
-        _G.sharedStarfield.parallaxY = 0
+        _G.sharedStarfield.parallaxY = 120
     end
 end
 
@@ -39,10 +39,12 @@ function scene_manager.update()
         local crankChange = playdate.getCrankChange()
         if math.abs(crankChange) > 0 then
             local height = _G.SCREEN_HEIGHT or 240
-            local maxOffset = height -- 240 for 240px screen
-            local newY = (_G.sharedStarfield.parallaxY or 0) - crankChange * 0.5
-            if newY < -maxOffset then newY = -maxOffset end
-            if newY > maxOffset then newY = maxOffset end
+            -- Limit max scroll so even with 1.5x multiplier, stars never leave the screen
+            local maxOffset = height / 2
+            local centerY = ((_G.sharedStarfield.height or (height*3)) - height) / 2
+            local newY = (_G.sharedStarfield.parallaxY or centerY) - crankChange * 0.5
+            if newY < centerY - maxOffset then newY = centerY - maxOffset end
+            if newY > centerY + maxOffset then newY = centerY + maxOffset end
             _G.sharedStarfield.parallaxY = newY
         end
     end

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -7,12 +7,10 @@ local currentScene = nil
 
 -- Initialize the global starfield (3x3 screens, centered)
 local function ensureStarfield()
-    local width = _G.SCREEN_WIDTH or 400
-    local height = _G.SCREEN_HEIGHT or 240
     if not _G.sharedStarfield then
-        _G.sharedStarfield = _G.Starfield.new(width * 3, height * 3, 150)
+        _G.sharedStarfield = _G.Starfield.new()
         _G.sharedStarfield.parallaxX = 0
-        _G.sharedStarfield.parallaxY = 120
+        _G.sharedStarfield.parallaxY = 0
     end
 end
 

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -5,12 +5,16 @@ local scene_manager = {}
 
 local currentScene = nil
 
+-- Constants for starfield and layout
+local STARFIELD_CENTER_Y = 120
+local SCREEN_HEIGHT = _G.SCREEN_HEIGHT or 240
+
 -- Initialize the global starfield (3x3 screens, centered)
 local function ensureStarfield()
     if not _G.sharedStarfield then
         _G.sharedStarfield = _G.Starfield.new()
         _G.sharedStarfield.parallaxX = 0
-        _G.sharedStarfield.parallaxY = 0
+        _G.sharedStarfield.parallaxY = STARFIELD_CENTER_Y
     end
 end
 
@@ -36,10 +40,8 @@ function scene_manager.update()
     if (currentScene == _G.menu_scene or currentScene == _G.highscore_scene) and _G.sharedStarfield then
         local crankChange = playdate.getCrankChange()
         if math.abs(crankChange) > 0 then
-            local height = _G.SCREEN_HEIGHT or 240
-            -- Limit max scroll so even with 1.5x multiplier, stars never leave the screen
-            local maxOffset = height / 2
-            local centerY = ((_G.sharedStarfield.height or (height*3)) - height) / 2
+            local maxOffset = SCREEN_HEIGHT / 1.5
+            local centerY = STARFIELD_CENTER_Y
             local newY = (_G.sharedStarfield.parallaxY or centerY) - crankChange * 0.5
             if newY < centerY - maxOffset then newY = centerY - maxOffset end
             if newY > centerY + maxOffset then newY = centerY + maxOffset end

--- a/Source/scenes/scene_manager.lua
+++ b/Source/scenes/scene_manager.lua
@@ -1,3 +1,5 @@
+local gfx <const> = playdate.graphics -- Add this line to define gfx
+
 -- scenes/scene_manager.lua
 local scene_manager = {}
 
@@ -26,6 +28,21 @@ function scene_manager.update()
 end
 
 function scene_manager.draw()
+    -- Always clear the screen to black first
+    local width = _G.SCREEN_WIDTH or 400
+    local height = _G.SCREEN_HEIGHT or 240
+    gfx.setColor(gfx.kColorBlack)
+    gfx.fillRect(0, 0, width, height)
+    -- Only draw the starfield if not in the transition scene
+    if currentScene ~= _G.slide_transition_scene then
+        local offsetX = 0
+        if currentScene == _G.highscore_scene then
+            offsetX = 2 * width
+        end
+        if _G.sharedStarfield and _G.sharedStarfield.draw then
+            _G.sharedStarfield:draw(width/2 + offsetX, height/2, 3 * width, height)
+        end
+    end
     if currentScene and currentScene.draw then
         currentScene:draw()
     end

--- a/Source/scenes/score_scene.lua
+++ b/Source/scenes/score_scene.lua
@@ -20,7 +20,7 @@ function score_scene:enter(finalScore, caught, missed)
     if _G.sharedStarfield then
         self.starfield = _G.sharedStarfield
     else
-        self.starfield = _G.Starfield.new(_G.SCREEN_WIDTH, _G.SCREEN_HEIGHT, 50)
+        self.starfield = _G.Starfield.new()
         _G.sharedStarfield = self.starfield
     end
     self.isNewHighScore = false
@@ -212,6 +212,11 @@ function score_scene:BButtonDown()
             self.initialsIndex = self.initialsIndex - 1
         end
     else
+        -- Create a new starfield when leaving the score scene
+        if _G.Starfield then
+            _G.sharedStarfield = _G.Starfield.new()
+            _G.sharedStarfield.parallaxY = 120
+        end
         if _G.switchToMenuScene then
             _G.switchToMenuScene()
         end

--- a/Source/scenes/score_scene.lua
+++ b/Source/scenes/score_scene.lua
@@ -14,15 +14,12 @@ local TITLE_Y = 80
 local STATS_Y = 140
 
 function score_scene:enter(finalScore, caught, missed)
+    self.starfield = _G.sharedStarfield
+    
     self.finalScore = finalScore or 0
     self.caught = caught or 0
     self.missed = missed or 0
-    if _G.sharedStarfield then
-        self.starfield = _G.sharedStarfield
-    else
-        self.starfield = _G.Starfield.new()
-        _G.sharedStarfield = self.starfield
-    end
+    
     self.isNewHighScore = false
     self.enteringInitials = false
     self.initialsChars = {' '} -- Start with space as blank entry
@@ -48,10 +45,6 @@ function score_scene:enter(finalScore, caught, missed)
         self.initialsIndex = 1
         self.blinkTimer = 0
     end
-end
-
-function score_scene:leave()
-    self.starfield = nil
 end
 
 function score_scene:update()
@@ -86,13 +79,6 @@ function score_scene:update()
 end
 
 function score_scene:draw()
-    -- Fill background and draw starfield
-    gfx.setImageDrawMode(gfx.kDrawModeCopy)
-    gfx.setColor(gfx.kColorBlack)
-    gfx.fillRect(0, 0, 400, 240)
-    if self.starfield then
-        self.starfield:draw(_G.SCREEN_WIDTH/2, _G.SCREEN_HEIGHT/2, _G.SCREEN_WIDTH, _G.SCREEN_HEIGHT)
-    end
     -- Move everything up if entering initials
     local yOffset = (self.enteringInitials and self.isNewHighScore) and -40 or 0
     -- Title background and text (match menu)

--- a/Source/scenes/slide_transition_scene.lua
+++ b/Source/scenes/slide_transition_scene.lua
@@ -1,0 +1,62 @@
+-- scenes/slide_transition_scene.lua
+local gfx <const> = playdate.graphics
+local slide_transition_scene = {}
+
+-- Use global menu_scene and highscore_scene for transition
+local menu_scene = _G.menu_scene
+local highscore_scene = _G.highscore_scene
+
+local DURATION = 0.5 -- seconds
+local FPS = 30
+local TOTAL_FRAMES = math.floor(DURATION * FPS)
+
+function slide_transition_scene:enter(direction)
+    self.frame = 0
+    self.direction = direction or 1 -- 1 for right, -1 for left
+    self.menu_scene = _G.menu_scene
+    self.highscore_scene = _G.highscore_scene
+    self.starfield = _G.sharedStarfield
+    self.width = _G.SCREEN_WIDTH
+    self.height = _G.SCREEN_HEIGHT
+end
+
+function slide_transition_scene:update()
+    self.frame = self.frame + 1
+    if self.frame >= TOTAL_FRAMES then
+        if self.direction == 1 then
+            if _G.switchToHighScoreScene then _G.switchToHighScoreScene() end
+        else
+            if _G.switchToMenuScene then _G.switchToMenuScene() end
+        end
+    end
+end
+
+function slide_transition_scene:draw()
+    local width = self.width or (_G and _G.SCREEN_WIDTH) or 400
+    local height = self.height or (_G and _G.SCREEN_HEIGHT) or 240
+    local t = math.min((self.frame or 0) / (TOTAL_FRAMES or 1), 1)
+    local slide = t * width
+    local menuX, highscoreX, starfieldX
+    if self.direction == 1 then
+        -- Menu -> Highscore (left to right)
+        menuX = -slide
+        highscoreX = width - slide
+        starfieldX = t * (2 * width)
+    else
+        -- Highscore -> Menu (right to left)
+        menuX = -width + slide
+        highscoreX = slide
+        starfieldX = (1 - t) * (2 * width)
+    end
+    if self.starfield and self.starfield.draw then
+        self.starfield:draw(width/2 + starfieldX, height/2, 3 * width, height)
+    end
+    if _G.menu_scene and _G.menu_scene.draw then
+        _G.menu_scene:draw(menuX, true)
+    end
+    if _G.highscore_scene and _G.highscore_scene.draw then
+        _G.highscore_scene:draw(highscoreX, true)
+    end
+end
+
+return slide_transition_scene


### PR DESCRIPTION
This pull request introduces significant updates to the starfield rendering system, scene transitions, and parallax effects in the game. It centralizes the starfield logic, improves parallax handling, and enhances the user experience with smooth transitions and layout refinements.

### Starfield and Parallax Enhancements:
* Centralized the starfield initialization in `scene_manager` to ensure a shared starfield instance across scenes. Added support for a 3x3 grid layout and vertical centering (`Source/scenes/scene_manager.lua`). [[1]](diffhunk://#diff-b67779d62b57d3563dcead007afe93e205ac54856ee65243f6099a942e9cff85R1-R27) [[2]](diffhunk://#diff-b67779d62b57d3563dcead007afe93e205ac54856ee65243f6099a942e9cff85R39-R73)
* Updated `Starfield` to include new constants (`NUM_STARS`, `GRID_SIZE`) and methods (`scrollParallaxY`) for improved parallax control. Adjusted the `draw` method to handle external parallax offsets (`Source/graphics/starfield.lua`). [[1]](diffhunk://#diff-b4abdf601345d2267a02a9e6d3382414403901e130ef57272bff443933ebcecdL8-R22) [[2]](diffhunk://#diff-b4abdf601345d2267a02a9e6d3382414403901e130ef57272bff443933ebcecdL25-R66)

### Scene Transition Improvements:
* Introduced global references for the `scene_manager`, `slide_transition_scene`, and other key scenes to enable smooth slide transitions (`Source/main.lua`).
* Modified `menu_scene` and `highscore_scene` to support x-offsets for transition animations and centralized parallax logic (`Source/scenes/menu_scene.lua`, `Source/scenes/highscore_scene.lua`). [[1]](diffhunk://#diff-5a2f78ace838f8e2bd6ce43af0dfc1c7ea5a09f836ffa02370d5ca0ca7d2f178L13-R68) [[2]](diffhunk://#diff-9d05722b9cbe35b424de649f47b1523a94a82cb4f02b9ceaa5c8a861e5537530R171-R177)

### Layout and Gameplay Adjustments:
* Adjusted constants for layout and spacing in `highscore_scene` and `menu_scene`, such as `LIST_W` and `STARFIELD_CENTER_Y`, for better alignment and visual consistency (`Source/scenes/highscore_scene.lua`, `Source/scenes/menu_scene.lua`). [[1]](diffhunk://#diff-9d05722b9cbe35b424de649f47b1523a94a82cb4f02b9ceaa5c8a861e5537530L7-R7) [[2]](diffhunk://#diff-5a2f78ace838f8e2bd6ce43af0dfc1c7ea5a09f836ffa02370d5ca0ca7d2f178R4-R6)
* Reduced `GAME_DURATION_MS` in `game_scene` for testing purposes and ensured seamless starfield transitions between gameplay and menu scenes (`Source/scenes/game_scene.lua`). [[1]](diffhunk://#diff-beaf7f703ac515e1c02e5f49e3fdca12df4aaa30e110b6c69eb7c96a3e1bd2f9L8-R8) [[2]](diffhunk://#diff-beaf7f703ac515e1c02e5f49e3fdca12df4aaa30e110b6c69eb7c96a3e1bd2f9L75-R85)

### Code Simplification:
* Removed redundant imports in `score_scene` to clean up unused dependencies (`Source/scenes/score_scene.lua`).