### PR TITLE
Zoom bar compass

### DIFF
--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -108,7 +108,7 @@ function game_scene:enter()
     -- Beam Zoom Sprite (right side, between titlebar and scoreboard)
     local beamZoomWidth = 5
     local beamZoomHeight = _G.SCREEN_HEIGHT - (_G.TIMERBAR_HEIGHT + _G.SCOREBOARD_HEIGHT)
-    local beamZoomX = _G.SCREEN_WIDTH - 20 -- 20px from right edge
+    local beamZoomX = _G.SCREEN_WIDTH - beamZoomWidth -- align right edge of sprite to screen edge
     local beamZoomY = _G.TIMERBAR_HEIGHT
     self.beamZoomSprite = gfx.sprite.new()
     self.beamZoomSprite:setCenter(0, 0)
@@ -117,21 +117,18 @@ function game_scene:enter()
     self.beamZoomSprite:setSize(beamZoomWidth, beamZoomHeight)
     self.beamZoomSprite.draw = function(_)
         gfx.setColor(gfx.kColorWhite)
-        -- Draw the main vertical line
-        gfx.drawLine(beamZoomWidth // 2, 0, beamZoomWidth // 2, beamZoomHeight)
-        -- Draw tick marks, denser at top/bottom, sparser in middle
-        local crankPos = playdate.getCrankPosition() or 0
-        local t = (crankPos % 360) / 360
-        local nTicks = 40
+        -- Draw the main vertical line at the far right edge of the sprite
+        gfx.drawLine(beamZoomWidth - 1, 0, beamZoomWidth - 1, beamZoomHeight)
+        -- Draw tick marks: density increases as beam gets closer to player
+        local minTicks = 10
+        local maxTicks = 60
+        local beamPercent = (self.beamRadius - self.minBeamRadius) / (self.maxBeamRadius - self.minBeamRadius)
+        local nTicks = math.floor(minTicks + (1 - beamPercent) * (maxTicks - minTicks))
         for i = 0, nTicks do
-            -- Use a cosine curve to space ticks: more at ends, fewer in middle
             local norm = i / nTicks
             local density = 0.5 * (1 - math.cos(norm * math.pi))
             local y = math.floor(density * (beamZoomHeight - 1))
-            -- Animate with crank: offset all lines by crank position
-            local offset = math.floor(t * (beamZoomHeight - 1))
-            local drawY = (y + offset) % beamZoomHeight
-            gfx.drawLine(0, drawY, beamZoomWidth, drawY)
+            gfx.drawLine(0, y, beamZoomWidth, y)
         end
     end
     self.beamZoomSprite:add()

--- a/Source/scenes/game_scene.lua
+++ b/Source/scenes/game_scene.lua
@@ -105,7 +105,36 @@ function game_scene:enter()
     -- Reset game state
     self:resetGameState()
 
-    
+    -- Beam Zoom Sprite (right side, between titlebar and scoreboard)
+    local beamZoomWidth = 5
+    local beamZoomHeight = _G.SCREEN_HEIGHT - (_G.TIMERBAR_HEIGHT + _G.SCOREBOARD_HEIGHT)
+    local beamZoomX = _G.SCREEN_WIDTH - 20 -- 20px from right edge
+    local beamZoomY = _G.TIMERBAR_HEIGHT
+    self.beamZoomSprite = gfx.sprite.new()
+    self.beamZoomSprite:setCenter(0, 0)
+    self.beamZoomSprite:moveTo(beamZoomX, beamZoomY)
+    self.beamZoomSprite:setZIndex(_G.ZINDEX and _G.ZINDEX.SCOREBOARD or 9998)
+    self.beamZoomSprite:setSize(beamZoomWidth, beamZoomHeight)
+    self.beamZoomSprite.draw = function(_)
+        gfx.setColor(gfx.kColorWhite)
+        -- Draw the main vertical line
+        gfx.drawLine(beamZoomWidth // 2, 0, beamZoomWidth // 2, beamZoomHeight)
+        -- Draw tick marks, denser at top/bottom, sparser in middle
+        local crankPos = playdate.getCrankPosition() or 0
+        local t = (crankPos % 360) / 360
+        local nTicks = 40
+        for i = 0, nTicks do
+            -- Use a cosine curve to space ticks: more at ends, fewer in middle
+            local norm = i / nTicks
+            local density = 0.5 * (1 - math.cos(norm * math.pi))
+            local y = math.floor(density * (beamZoomHeight - 1))
+            -- Animate with crank: offset all lines by crank position
+            local offset = math.floor(t * (beamZoomHeight - 1))
+            local drawY = (y + offset) % beamZoomHeight
+            gfx.drawLine(0, drawY, beamZoomWidth, drawY)
+        end
+    end
+    self.beamZoomSprite:add()
 end
 
 -- Spawns a new flying object using the spawner

--- a/Source/ui/beam_zoom_sprite.lua
+++ b/Source/ui/beam_zoom_sprite.lua
@@ -1,0 +1,51 @@
+-- BeamZoomSprite: UI sprite for visualizing beam proximity (zoom bar)
+-- Usage: local zoomBar = BeamZoomSprite.new(parentScene)
+
+local gfx <const> = playdate.graphics
+
+local BeamZoomSprite = {}
+BeamZoomSprite.__index = BeamZoomSprite
+
+function BeamZoomSprite.new(parentScene)
+    local self = setmetatable({}, BeamZoomSprite)
+    self.parentScene = parentScene
+    self.width = 5
+    self.height = _G.SCREEN_HEIGHT - (_G.TIMERBAR_HEIGHT + _G.SCOREBOARD_HEIGHT) - 8 -- was -4, now -8 for 2px less on top and bottom
+    self.x = _G.SCREEN_WIDTH - self.width
+    self.y = _G.TIMERBAR_HEIGHT + 4 -- was +2, now +4 for 2px lower
+    self.sprite = gfx.sprite.new()
+    self.sprite:setCenter(0, 0)
+    self.sprite:moveTo(self.x, self.y)
+    self.sprite:setZIndex(_G.ZINDEX and _G.ZINDEX.SCOREBOARD or 9998)
+    self.sprite:setSize(self.width, self.height)
+    self.sprite.draw = function(_)
+        gfx.setColor(gfx.kColorWhite)
+        -- Draw the main vertical line at the far right edge of the sprite
+        gfx.drawLine(self.width - 1, 0, self.width - 1, self.height)
+        -- Draw tick marks: density increases as beam gets closer to player
+        local minTicks = 5
+        local maxTicks = 60
+        local beamRadius = self.parentScene.beamRadius or 20
+        local minBeam = self.parentScene.minBeamRadius or 15
+        local maxBeam = self.parentScene.maxBeamRadius or 75
+        local beamPercent = (beamRadius - minBeam) / (maxBeam - minBeam)
+        local nTicks = math.floor(minTicks + (1 - beamPercent) * (maxTicks - minTicks))
+        for i = 0, nTicks do
+            local norm = i / nTicks
+            local density = 0.5 * (1 - math.cos(norm * math.pi))
+            local y = math.floor(density * (self.height - 1))
+            gfx.drawLine(0, y, self.width, y)
+        end
+    end
+    self.sprite:add()
+    return self
+end
+
+function BeamZoomSprite:remove()
+    if self.sprite then
+        self.sprite:remove()
+        self.sprite = nil
+    end
+end
+
+return BeamZoomSprite


### PR DESCRIPTION
This pull request introduces a new UI element for visualizing beam proximity in the game, implemented as a "beam zoom" sprite. The changes include adding the sprite directly in the game scene and creating a reusable `BeamZoomSprite` class for better modularity and maintainability.

### New Beam Zoom Sprite Implementation:

* **Inline Implementation in `game_scene.lua`:**
  - Added a `beamZoomSprite` directly in the `game_scene:enter()` method to display a visual representation of beam proximity. This includes logic for drawing a vertical line and dynamically adjusting tick marks based on the beam's distance from the player.

* **Reusable `BeamZoomSprite` Class:**
  - Introduced a new `BeamZoomSprite` class in `beam_zoom_sprite.lua` for modular and reusable implementation of the beam zoom UI. This class encapsulates the sprite's creation, positioning, drawing logic, and cleanup. It provides a consistent interface for managing the beam zoom sprite across scenes.